### PR TITLE
Run alters directly for some small tables

### DIFF
--- a/ui/app/views/migrations/_detail.html.erb
+++ b/ui/app/views/migrations/_detail.html.erb
@@ -113,7 +113,7 @@
   <% if @status.action %>
     <% unless @migration.parsed[:error] %>
       <% if show_approve? %>
-        <% if @migration.parsed[:run] == :short %>
+        <% if @migration.parsed[:run] == :short || @migration.small_enough_for_short_run? %>
           <div class="row detail_button">
             <div class="col-md-1 col-md-offset-3">
               <%= button_to "#{@status.action}",
@@ -163,7 +163,8 @@
           </div>
         <% end %>
         <% if @migration.parsed[:run] == :maybeshort ||
-              @migration.parsed[:run] == :long %>
+              @migration.parsed[:run] == :long &&
+              !@migration.small_enough_for_short_run? %>
           <div class="row detail_button">
             <div class="col-md-1 col-md-offset-3">
               <%= button_to "#{@status.action}",


### PR DESCRIPTION
I excluded adding support to do this for migrations that belong to a meta_request for right now because doing so will require a significant amount of work.

Sample error that this would avoid:
```
[2016-02-26 16:55:13] stdout: 2016-02-26T16:55:13 Copying approximately 3889 rows...
26T16:55:14 Cannot copy table `database1`.`tablename` because on the master it would be checksummed in one chunk but on these replicas it has too many rows:
[2016-02-26 16:55:14] stderr:   4194 rows on slave1
````

@SheepGoesBaa 