### PR TITLE
Prevent inconsistent string/symbol usage from exposing passwords

### DIFF
--- a/ui/app/services/mysql_helper.rb
+++ b/ui/app/services/mysql_helper.rb
@@ -25,6 +25,7 @@ class MysqlHelper
           :connect_timeout => 5})
       @client = Mysql2::Client.new(config)
     rescue Mysql2::Error => e
+      config = config.symbolize_keys # prevent inconsistent string/symbol usage from exposing passwords
       config[:password] = "*****" if config[:password]
       raise MysqlError, "Problem establishing mysql connection (error: #{e}) (connection info: #{config})"
     end


### PR DESCRIPTION
## Summary

If `config` contains a mix of strings/symbols as keys, it can lead to the password being exposed in the UI (which we just experienced)

I believe this is because we are using yaml config (as opposed to the ruby config recommended here: https://github.com/square/shift/tree/master/ui#configuration) but I haven't spent much time figuring out the root cause for the difference because the fix is so harmless

## Testing

This fix works for me when running the app. I tried to confirm that `symbolize_keys` is in all the rails versions permitted by shift, but it seems like apidock is down. Lemme know if you know of another way